### PR TITLE
Adds check for online instances

### DIFF
--- a/lib/opsworks_interactor.rb
+++ b/lib/opsworks_interactor.rb
@@ -98,6 +98,9 @@ class OpsworksInteractor
     instances = @opsworks_client.describe_instances(layer_id: layer_id)[:instances]
 
     instances.each do |instance|
+      # Only deploy to online instances
+      next unless instance.status == 'online'
+
       begin
         log("=== Starting deploy for #{instance.hostname} ===")
 


### PR DESCRIPTION
Hi there

I just wanted to add a check so deploy's only run on instances that are `online`. We sometimes have some stopped instances during low traffic periods and AWS error's when it tries to deploy to them.

Thanks
